### PR TITLE
Mark jupyter notebooks as documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
Fixes: https://github.com/gldraphael/scale/issues/12
See: https://github.com/github-linguist/linguist/issues/3316


Before & after this change:

![image](https://github.com/user-attachments/assets/5e6cbf10-c524-48de-a52b-e523df42b341)
