### PR TITLE
Add the missing has_family_history and freq_high_calorie_intake fields

### DIFF
--- a/apps/messages/classify_obesity_level_request.proto
+++ b/apps/messages/classify_obesity_level_request.proto
@@ -13,12 +13,14 @@ message ClassifyObesityLevelRequest {
     float weight                   = 4;
     float veg_in_meals             = 5;
     uint32 num_meals               = 6;
-    Frequency food_bw_meals = 7;
+    Frequency food_bw_meals        = 7;
     bool is_smoker                 = 8;
     float water_intake             = 9;
     bool monitors_calories         = 10;
     float physical_act_freq        = 11;
     float screen_time              = 12;
-    Frequency alcohol_freq  = 13;
+    Frequency alcohol_freq         = 13;
     Transportation transportation  = 14;
+    bool has_family_history        = 15;
+    bool freq_high_calorie_intake  = 16;
 }

--- a/apps/pyworker/src/scale/services/ScaleService.py
+++ b/apps/pyworker/src/scale/services/ScaleService.py
@@ -18,7 +18,7 @@ class ScaleService(ScaleServiceBase):
         if ScaleService.__clf is None:
             raise ValueError("The model was not loaded. Did you call ScaleService.load()?")
         
-        user_input_values = [request.sex.name.lower(),request.age,request.height,request.weight,False,False,request.veg_in_meals,request.num_meals,request.food_bw_meals.name.lower(),request.is_smoker,request.water_intake,request.monitors_calories,request.physical_act_freq,request.screen_time,request.alcohol_freq.name.lower(),request.transportation.name.lower()]
+        user_input_values = [request.sex.name.lower(),request.age,request.height,request.weight,request.has_family_history,request.freq_high_calorie_intake,request.veg_in_meals,request.num_meals,request.food_bw_meals.name.lower(),request.is_smoker,request.water_intake,request.monitors_calories,request.physical_act_freq,request.screen_time,request.alcohol_freq.name.lower(),request.transportation.name.lower()]
         print(user_input_values)
         encoded_user_input_values = [ScaleService.__mapper.encode(i) for i in user_input_values]
         model_input = DataFrame([encoded_user_input_values], columns=ScaleService.__feature_names)

--- a/apps/reactapp/src/Steps.tsx
+++ b/apps/reactapp/src/Steps.tsx
@@ -13,6 +13,7 @@ export default function Steps(){
     const [weight, setWeight] = useState(65);
     const [hasFamilyHistory, setHasFamilyHistory] = useState(false);
 
+    const [hasHighCalorieDiet, setHasHighCalorieDiet] = useState(false)
     const [waterIntake, setWaterIntake] = useState(2.5);
     const [monitorsCalories, setMonitorsCalories] = useState(false);
     const [numMainMeals, setNumMainMeals] = useState(3);
@@ -141,6 +142,21 @@ export default function Steps(){
               </RadioGroup.Root>
             </Box>
 
+            <Box>
+              <label>Do you frequently have high calorie meals?</label>
+              <RadioGroup.Root
+                value={hasHighCalorieDiet.toString()}
+                onValueChange={(val) => setHasHighCalorieDiet(val.toLowerCase() == 'true')}
+                aria-label="Do you frequently have high calorie meals?"
+              >
+                <RadioGroup.Item value='true' autoFocus>
+                  <label>Yes</label>
+                </RadioGroup.Item>
+                <RadioGroup.Item value='false'>
+                  <label>No</label>
+                </RadioGroup.Item>
+              </RadioGroup.Root>
+            </Box>
             
             <Box>
               <label>How many main meals do you typically eat in a day</label>
@@ -285,7 +301,9 @@ export default function Steps(){
                   physical_act_freq: physicalActivityFreq,
                   screen_time: screenTime,
                   transportation: travel,
-                  water_intake: waterIntake
+                  water_intake: waterIntake,
+                  has_family_history: hasFamilyHistory,
+                  has_high_calorie_diet: hasHighCalorieDiet
                 }))
                 if(response != null) {
                   setResponse(response)

--- a/apps/reactapp/src/services/ApiService.ts
+++ b/apps/reactapp/src/services/ApiService.ts
@@ -21,6 +21,8 @@ export class ApiService {
               transportation: req.transportation,
               veg_in_meals: req.veg_in_meals,
               water_intake: req.water_intake,
+              has_family_history: req.has_family_history,
+              has_high_calorie_diet: req.has_high_calorie_diet
             })
           })
         return await response.json() as ClassificationResponse
@@ -37,7 +39,9 @@ interface ClassificationRequest {
   sex: Sex
   weight: number
   height: number
-
+  
+  has_family_history: boolean
+  has_high_calorie_diet: boolean
   monitors_calories: boolean
   num_meals: number
   veg_in_meals: number

--- a/apps/webapi/src/api/main_api.rs
+++ b/apps/webapi/src/api/main_api.rs
@@ -48,7 +48,9 @@ async fn classify(State(config): State<Config>, Json(req): Json<ClassificationRe
             monitors_calories: req.monitors_calories,
             screen_time: req.screen_time,
             alcohol_freq: gen::Frequency::from_repr(req.alcohol_freq as i32).unwrap().into(),
-            transportation: gen::Transportation::from_repr(req.transportation as i32).unwrap().into()
+            transportation: gen::Transportation::from_repr(req.transportation as i32).unwrap().into(),
+            has_family_history: req.has_family_history,
+            freq_high_calorie_intake: req.has_high_calorie_diet
         });
         
         let response = client.classify_obesity_level(request).await.unwrap();
@@ -72,7 +74,9 @@ struct ClassificationRequest {
     physical_act_freq: f32,
     screen_time: f32,
     alcohol_freq: AlcoholFrequency,
-    transportation: Transportation
+    transportation: Transportation,
+    has_family_history: bool,
+    has_high_calorie_diet: bool
 }
 
 #[derive(Serialize, ToSchema)]


### PR DESCRIPTION
The values for these fields were being hard-coded until now. This commit
updates the UI to accept `freq_high_calorie_intake`, and updates the
message contract to accept both of the fields so that they are no longer
hardcoded during classification.

Closes https://github.com/gldraphael/scale/issues/9
